### PR TITLE
Fix crash when moving destroyed objects

### DIFF
--- a/game.js
+++ b/game.js
@@ -221,9 +221,14 @@ function update(time, delta) {
 
     // Enemies chase player and use abilities
     enemies.children.iterate(enemy => {
-        if (!enemy) return;
+        // Skip if the enemy has been destroyed or its body removed
+        if (!enemy || !enemy.active || !enemy.body) {
+            return;
+        }
+
         const speedVal = enemy.ability === 'fast' ? 150 : 100;
         this.physics.moveToObject(enemy, player, speedVal);
+
         if (enemy.ability === 'shoot') {
             enemy.shootTimer += delta;
             if (enemy.shootTimer > 2000) {
@@ -234,7 +239,7 @@ function update(time, delta) {
     });
 
     // Boss behavior
-    if (boss) {
+    if (boss && boss.active && boss.body) {
         this.physics.moveToObject(boss, player, 80);
         bossShootTimer += delta;
         if (bossShootTimer > 1500) {


### PR DESCRIPTION
## Summary
- avoid moving enemies or boss objects that are no longer active

## Testing
- `node --check game.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862e89314c4832cb4edd00b1a5800ce