### PR TITLE
Implement endless auto-shoot gameplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Orda.IO
+
+Simple Phaser 3 prototype with automatic shooting and endless gameplay.


### PR DESCRIPTION
## Summary
- switch to endless mode by removing win timer
- fire automatically at the nearest enemy within range
- clean up README to describe the prototype

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6862f1741510832cba65d12917f908ad