### PR TITLE
Use PNG enemy sprite

### DIFF
--- a/game.js
+++ b/game.js
@@ -86,12 +86,6 @@ function createTextures(scene) {
     bulletGfx.generateTexture('bullet', 10, 10);
     bulletGfx.destroy();
 
-    const enemyGfx = scene.add.graphics();
-    enemyGfx.fillStyle(0xff0000, 1);
-    enemyGfx.fillRect(0, 0, 30, 30);
-    enemyGfx.generateTexture('enemy', 30, 30);
-    enemyGfx.destroy();
-
     const enemyBulletGfx = scene.add.graphics();
     enemyBulletGfx.fillStyle(0xff8800, 1);
     enemyBulletGfx.fillCircle(4, 4, 4);
@@ -142,6 +136,7 @@ function createTextures(scene) {
 }
 
 function preload() {
+    this.load.image('enemy', 'Imagen/enemi1.png');
     createTextures(this);
 }
 
@@ -483,6 +478,7 @@ function spawnEnemy(x, y) {
         }
     }
     const enemy = enemies.create(x, y, 'enemy');
+    enemy.setDisplaySize(40, 40);
     enemy.setCollideWorldBounds(true);
     enemy.maxHealth = BASE_ENEMY_HEALTH * enemyLevelMultiplier;
     enemy.health = enemy.maxHealth;
@@ -490,7 +486,7 @@ function spawnEnemy(x, y) {
     enemy.healthBar = this.add.graphics();
     enemy.updateHealthBar = () => {
         enemy.healthBar.clear();
-        const width = 30;
+        const width = 40;
         const hx = enemy.x - width / 2;
         const hy = enemy.y - 20;
         enemy.healthBar.fillStyle(0xff0000, 1);


### PR DESCRIPTION
## Summary
- load `Imagen/enemi1.png` as enemy texture
- scale enemies to 40x40 when spawned
- adjust enemy health bar width
- stop generating the placeholder square enemy (from previous commit)

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686303e7d9f8832c9db10edee0ff4d00